### PR TITLE
resolve ptyagi16/guard-consistency_fail/issues/3 and ptyagi16/guard-consistency_fail/issues/2

### DIFF
--- a/lib/guard/consistency_fail.rb
+++ b/lib/guard/consistency_fail.rb
@@ -7,13 +7,16 @@ module Guard
     # :environment        defaults to 'development'
 
     def initialize(options = {})
-      @options = options
-      @watchers = options[:watchers]
       super
+      @options = {
+        all_on_start: true,
+        rails_app_dir: '.'
+      }.merge(options)
+      @watchers = options[:watchers]
     end
 
     def start
-      system(cmd)
+      run_all if @options[:all_on_start]
     end
 
     # Called on Ctrl-C signal (when Guard quits)
@@ -29,7 +32,7 @@ module Guard
     # Called on Ctrl-/ signal
     # This method should be principally used for long action like running all specs/tests/...
     def run_all
-      start
+      system(cmd)
     end
 
     # Called on file(s) modifications
@@ -41,6 +44,7 @@ module Guard
 
     def cmd
       command = 'consistency_fail'
+      command += " #{@options[:rails_app_dir]}" if '.' != @options[:rails_app_dir]
       command = "export RAILS_ENV=#{@options[:environment]}; #{command}" if @options[:environment]
       Compat::UI.info "Running consistency_fail: #{command}"
       command

--- a/lib/guard/consistency_fail/templates/Guardfile
+++ b/lib/guard/consistency_fail/templates/Guardfile
@@ -1,4 +1,4 @@
-guard 'consistency_fail', :environment => 'development' do
+guard 'consistency_fail', :environment => 'development', :rails_app_dir => '.', :all_on_start => true do
   watch(%r{^app/model/(.+)\.rb})
   watch(%r{^db/schema.rb})
 end

--- a/lib/guard/consistency_fail/version.rb
+++ b/lib/guard/consistency_fail/version.rb
@@ -1,5 +1,5 @@
 module Guard
   module ConsistencyFailVersion
-    VERSION = '0.1.1'
+    VERSION = '0.1.2'
   end
 end

--- a/spec/guard/consistency_fail_spec.rb
+++ b/spec/guard/consistency_fail_spec.rb
@@ -2,20 +2,62 @@ require 'spec_helper'
 require 'guard/compat/test/helper'
 
 describe Guard::ConsistencyFail do
-  describe "when passing an environment option" do
+  describe '#options' do
+    context 'when unspecified' do
+      it 'rails_app_dir is set to current directory' do
+        expect(subject.options.fetch(:rails_app_dir)).to eq('.')
+      end
 
-    let(:consistency_fail) {Guard::ConsistencyFail.new({watchers:[], environment: 'test'})}
+      it 'all_on_start is true' do
+        expect(subject.options.fetch(:all_on_start)).to be_truthy
+      end
+    end
+  end
 
+  context 'running with various options' do
     before do
       allow(Guard::Compat::UI).to receive(:notify)
       allow(Guard::Compat::UI).to receive(:info)
       allow(Guard::Compat::UI).to receive(:error)
     end
 
-    it "calls system with 'export RAILS_ENV=test;' call first" do
+    context 'whith all_on_start set to true' do
+      let(:consistency_fail) {Guard::ConsistencyFail.new({watchers:[], all_on_start: true})}
 
-      expect(consistency_fail).to receive(:system).with("export RAILS_ENV=test; consistency_fail").and_return(true)
-      consistency_fail.start
+      it 'do run on start' do
+        expect(consistency_fail).to receive(:run_all)
+        consistency_fail.start
+      end
+    end
+
+    context 'whith all_on_start set to false' do
+      let(:consistency_fail) {Guard::ConsistencyFail.new({watchers:[], all_on_start: false})}
+
+      it 'does nothing' do
+        expect(consistency_fail).to_not receive(:run_all)
+        consistency_fail.start
+      end
+
+    end
+
+    describe 'whith rails_app_dir other than .' do
+      let(:consistency_fail) {Guard::ConsistencyFail.new({watchers:[], rails_app_dir: 'azerty'})}
+
+      it "calls system with 'azerty' as rails_app_dir" do
+        expect(consistency_fail).to receive(:system).with("consistency_fail azerty").and_return(true)
+        consistency_fail.start
+      end
+    end
+
+    describe "when passing an environment option" do
+
+      let(:consistency_fail) {Guard::ConsistencyFail.new({watchers:[], environment: 'test'})}
+
+      it "calls system with 'export RAILS_ENV=test;' call first" do
+
+        expect(consistency_fail).to receive(:system).with("export RAILS_ENV=test; consistency_fail").and_return(true)
+        consistency_fail.start
+      end
     end
   end
 end


### PR DESCRIPTION
- use trptcolin/consistency_fail/pull/38 ability to pass rails_base dir as an argument (but keep current directory as default argument) and resolve  ptyagi16/guard-consistency_fail/issues/2
- resolve ptyagi16/guard-consistency_fail/issues/3 (add all_on_start option)
- Guard template updated
- several specs added
- version bumped

I forgot to update the Readme, sorry.
